### PR TITLE
Bugfix for report

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -76,7 +76,8 @@ function tostring(mval, merr; pm="±")
         # m = measurement(mval, merr)
         # return @sprintf("$m")
     elseif mval isa Complex && merr isa Complex && isfinite(mval) && isfinite(merr)
-        m = measurement(real(mval), real(merr)) + measurement(imag(mval), imag(merr)) * 1im
+        m = @sprintf("%16.6g(%6g) + %16.6g(%6g)im", real(mval), real(merr), imag(mval), imag(merr))
+        # m = measurement(real(mval), real(merr)) + measurement(imag(mval), imag(merr)) * 1im
         # return @sprintf("%16.6g(%6g) + %16.6g(%6g)im", real(mval), real(merr), imag(mval), imag(merr))
     else
         m = "$mval $pm $merr"

--- a/test/montecarlo.jl
+++ b/test/montecarlo.jl
@@ -127,6 +127,21 @@ function TestComplex2_inplace(totalstep, alg)
     return res
 end
 
+@testset "Report" begin
+    neval = 1000_00
+    results = [
+        Sphere1(neval, :vegas),
+        Sphere2(neval, :vegas),
+        TestComplex1(neval, :vegas),
+        TestComplex2(neval, :vegas),
+    ]
+    for result in results
+        @test redirect_stdout(devnull) do
+            isnothing(report(result))
+        end
+    end
+end
+
 @testset "MCMC Sampler" begin
     neval = 1000_00
     println("MCMC tests")


### PR DESCRIPTION
Remove missing `Measurements` dependency from function `tostring` for complex measurement types and add unit tests for report functionality.